### PR TITLE
Exclude the property mimetype on post (issue #67)

### DIFF
--- a/surf/src/main/amp/web/components/uploader-plus/js/dnd-upload-plus.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/dnd-upload-plus.js
@@ -178,8 +178,10 @@
                             Alfresco.logger.debug("Current:", current);
                             if (fileInfo.propertyData.hasOwnProperty(current) &&
                                 (current.indexOf("prop_") === 0 || current.indexOf("assoc_") === 0)) {
-                                Alfresco.logger.debug("Appending", current);
-                                formData.append(current, fileInfo.propertyData[current]);
+                                if (current != "prop_mimetype" || (current == "prop_mimetype" && fileInfo.propertyData[current] && fileInfo.propertyData[current].length > 0)) {
+                                    Alfresco.logger.debug("Appending", current);
+                                    formData.append(current, fileInfo.propertyData[current]);
+                                }
                             }
                         }
                     }
@@ -250,8 +252,10 @@
                         for (var current in fileInfo.propertyData) {
                             if (fileInfo.propertyData.hasOwnProperty(current) &&
                                 (current.indexOf("prop_") === 0 || current.indexOf("assoc_") === 0)) {
-                                customFormData += rn + "Content-Disposition: form-data; name=\"" + current + "\"";
-                                customFormData += rn + rn + unescape(encodeURIComponent(fileInfo.propertyData[current])) + rn + "--" + multipartBoundary + "--";
+                                if (current != "prop_mimetype" || (current == "prop_mimetype" && fileInfo.propertyData[current] && fileInfo.propertyData[current].length > 0)) {
+                                    customFormData += rn + "Content-Disposition: form-data; name=\"" + current + "\"";
+                                    customFormData += rn + rn + unescape(encodeURIComponent(fileInfo.propertyData[current])) + rn + "--" + multipartBoundary + "--";
+                                }
                             }
                         }
                     }

--- a/surf/src/main/amp/web/components/uploader-plus/js/flash-upload-plus.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/flash-upload-plus.js
@@ -203,8 +203,10 @@
                                     Alfresco.logger.debug("Current:", current);
                                     if (fileInfo.propertyData.hasOwnProperty(current) &&
                                         (current.indexOf("prop_") === 0 || current.indexOf("assoc_") === 0)) {
-                                        Alfresco.logger.debug("Adding attribute", current);
-                                        attributes[current] = fileInfo.propertyData[current];
+                                        if (current != "prop_mimetype" || (current == "prop_mimetype" && fileInfo.propertyData[current] && fileInfo.propertyData[current].length > 0)) {
+                                            Alfresco.logger.debug("Adding attribute", current);
+                                            attributes[current] = fileInfo.propertyData[current];
+                                        }
                                     }
                                 }
                             }

--- a/surf/src/main/amp/web/components/uploader-plus/js/html-upload-plus.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/html-upload-plus.js
@@ -130,12 +130,14 @@
                     Alfresco.logger.debug("Current:", current);
                     if (propertyData.hasOwnProperty(current) &&
                         (current.indexOf("prop_") === 0 || current.indexOf("assoc_") === 0)) {
-                        Alfresco.logger.debug("Adding property", current);
-                        var input = document.createElement("input");
-                        input.setAttribute("type", "hidden");
-                        input.setAttribute("name", current);
-                        input.setAttribute("value", propertyData[current]);
-                        submitForm.appendChild(input);
+                        if (current != "prop_mimetype" || (current == "prop_mimetype" && propertyData[current] && propertyData[current].length > 0)) {
+                            Alfresco.logger.debug("Adding property", current);
+                            var input = document.createElement("input");
+                            input.setAttribute("type", "hidden");
+                            input.setAttribute("name", current);
+                            input.setAttribute("value", propertyData[current]);
+                            submitForm.appendChild(input);
+                        }
                     }
                 }
 


### PR DESCRIPTION
* No need to set the mimetype property, alfresco adds this in the CreateFile
method (ScriptNode class),
* An empty value or not, gives mimetype value "Binary File" in all cases. So
do not send the property "prop_mimetype".