### PR TITLE
 fix for 'is not defined' error messages on pages where the uploader is not loaded

### DIFF
--- a/surf/src/main/amp/config/alfresco/site-webscripts/com/softwareloop/customization/file-upload.get.html.ftl
+++ b/surf/src/main/amp/config/alfresco/site-webscripts/com/softwareloop/customization/file-upload.get.html.ftl
@@ -1,8 +1,8 @@
 <@markup id="custom-widgets" target="widgets" action="after" scope="global">
     <@inlineScript group="upload">
         Alfresco.getFileUploadInstance().setOptions({
-            flashUploader : YAHOO.lang.isObject(SoftwareLoop) && YAHOO.lang.isFunction(SoftwareLoop.FlashUpload) ? "SoftwareLoop.FlashUpload" : "Alfresco.FlashUpload",
-            htmlUploader : YAHOO.lang.isObject(SoftwareLoop) && YAHOO.lang.isFunction(SoftwareLoop.HtmlUpload) ? "SoftwareLoop.HtmlUpload" : "Alfresco.HtmlUpload"
+            flashUploader : typeof SoftwareLoop!="undefined" && YAHOO.lang.isFunction(SoftwareLoop.FlashUpload) ? "SoftwareLoop.FlashUpload" : "Alfresco.FlashUpload",
+            htmlUploader : typeof SoftwareLoop!="undefined" && YAHOO.lang.isFunction(SoftwareLoop.HtmlUpload) ? "SoftwareLoop.HtmlUpload" : "Alfresco.HtmlUpload"
         });
         
         Alfresco.getDNDUploadProgressInstance = function()


### PR DESCRIPTION
tested on 5.1.1 Enterprise
