### PR TITLE
Aspect support for cm:content

### DIFF
--- a/repo/src/main/amp/config/alfresco/module/uploader-plus-repo/model/uploader-plus-model.xml
+++ b/repo/src/main/amp/config/alfresco/module/uploader-plus-repo/model/uploader-plus-model.xml
@@ -30,6 +30,17 @@
                         <tokenised>false</tokenised>
                     </index>
                 </property>
+                <property name="up:allowedProxyTypes">
+                    <title>Allowed proxy types</title>
+                    <type>d:text</type>
+                    <mandatory>false</mandatory>
+                    <multiple>true</multiple>
+                    <index enabled="true">
+                        <atomic>true</atomic>
+                        <stored>false</stored>
+                        <tokenised>false</tokenised>
+                    </index>
+                </property>
             </properties>
         </aspect>
     </aspects>

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.js
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.js
@@ -43,6 +43,8 @@ while (destNode !== null && !destNode.hasAspect("up:UploadFolder")) {
 
 if (destNode === null) {
     model.types = null;
+    model.proxyTypes = null;
 } else {
     model.types = destNode.properties["up:allowedTypes"];
+    model.proxyTypes = destNode.properties["up:allowedProxyTypes"];
 }

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.json.ftl
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.json.ftl
@@ -10,5 +10,16 @@
     <#else>
     null
     </#if>
+,
+"proxyTypes" :
+    <#if proxyTypes??>
+    [
+        <#list proxyTypes as proxyType>
+        "${proxyType}"<#if proxyType_has_next>,</#if>
+        </#list>
+    ]
+    <#else>
+    null
+    </#if>
 }
 </#escape>

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-list.get.json.ftl
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-list.get.json.ftl
@@ -11,6 +11,13 @@
             "${allowedType}"<#if allowedType_has_next>,</#if>
             </#list>
         </#if>
+    ],
+    "allowedProxyTypes": [
+        <#if node.properties["up:allowedProxyTypes"]??>
+            <#list node.properties["up:allowedProxyTypes"] as allowedProxyType>
+            "${allowedProxyType}"<#if allowedProxyType_has_next>,</#if>
+            </#list>
+        </#if>
     ]
     }<#if node_has_next>,</#if>
     </#list>

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-new.post.js
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-new.post.js
@@ -13,6 +13,7 @@ if (node.hasAspect("up:UploadFolder")) {
     } else {
     var props = new Array(2);
     props["up:allowedTypes"] = null;
+    props["up:allowedProxyTypes"] = null;
     node.addAspect("up:UploadFolder", props);
     node.save();
 

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-new.post.json.ftl
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/upload-folders-new.post.json.ftl
@@ -4,7 +4,8 @@
 "node": {
 "nodeRef": "${node.nodeRef}",
 "path": "${node.displayPath}\/${node.properties.name}",
-"allowedTypes": []
+"allowedTypes": [],
+"allowedProxyTypes": []
 }
 }
 </#escape>

--- a/surf/src/main/amp/config/alfresco/site-webscripts/com/softwareloop/uploader-plus/uploader-plus-admin.get.properties
+++ b/surf/src/main/amp/config/alfresco/site-webscripts/com/softwareloop/uploader-plus/uploader-plus-admin.get.properties
@@ -1,5 +1,6 @@
 title.path = Path
 title.allowed.types = Allowed types
+title.allowed.proxyTypes= Allowed proxy types
 title.actions = Actions
 loading.folders = Loading folders
 no.folders.found = No folders found

--- a/surf/src/main/amp/web/components/uploader-plus/css/uploader-plus-admin.css
+++ b/surf/src/main/amp/web/components/uploader-plus/css/uploader-plus-admin.css
@@ -50,7 +50,7 @@ div.yui-u.edit-metadata.flat-button {
     display: none;
 }
 
-.form-container select.supported-types-select {
+.form-container select.supported-types-select, .form-container select.supported-proxy-types-select  {
     width: 100%;
     height: 20em;
 }

--- a/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-admin.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-admin.js
@@ -101,6 +101,12 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
                 formatter: SoftwareLoop.hitch(this, this.allowedTypesFormatter)
             },
             {
+                key: "allowedProxyTypes",
+                label: this.msg("title.allowed.proxyTypes"),
+                sortable: false,
+                formatter: SoftwareLoop.hitch(this, this.allowedTypesFormatter)
+            },
+            {
                 key: "actions",
                 label: this.msg("title.actions"),
                 sortable: false,
@@ -116,7 +122,7 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
                 connXhrMode: "queueRequests",
                 responseSchema: {
                     resultsList: "results",
-                    fields: ["path", "nodeRef", "allowedTypes"]
+                    fields: ["path", "nodeRef", "allowedTypes", "allowedProxyTypes"]
                 }
             });
 
@@ -299,10 +305,11 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
                         titleNode.innerHTML =
                             Alfresco.util.encodeHTML(this.prettyPath(data.path));
                     }
-                    var selectNode = YAHOO.util.Dom.getElementsByClassName(
+                    var supportedTypes = YAHOO.util.Dom.getElementsByClassName(
                         "supported-types-select", "select")[0];
-
-                    this.populateAllowedTypesSelect(selectNode);
+                    var supportedProxyTypes = YAHOO.util.Dom.getElementsByClassName(
+                        "supported-proxy-types-select", "select")[0];
+                    this.populateAllowedTypesSelect(supportedTypes, supportedProxyTypes);
 
                     return true;
                 },
@@ -313,6 +320,7 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
                     Alfresco.logger.debug("onSuccess callback", arguments);
                     var dataObj = response.config.dataObj;
                     data.allowedTypes = dataObj.prop_up_allowedTypes.split(",");
+                    data.allowedProxyTypes = dataObj.prop_up_allowedProxyTypes.split(",");
                     this.widgets.dataTable.updateRow(record, data);
                     Alfresco.util.PopupManager.displayMessage({
                         text: this.msg("operation.completed.successfully")
@@ -369,12 +377,18 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
         Alfresco.logger.debug("END deleteUploadFolderHandler");
     },
 
-    populateAllowedTypesSelect: function (selectNode) {
+    populateAllowedTypesSelect: function (allowedTypes, allowedProxyTypes) {
         Alfresco.logger.debug("populateAllowedTypesSelect", arguments);
-        var selectedValues = selectNode.getAttribute("data-selectedValues");
-        var selectedValuesArray = [];
-        if (selectedValues) {
-            selectedValuesArray = selectedValues.split(",");
+        var selectedAllowedTypeValues = allowedTypes.getAttribute("data-selectedValues");
+        var selectedAllowedTypeValuesArray = [];
+        if (allowedTypes) {
+            selectedAllowedTypeValuesArray = selectedAllowedTypeValues.split(",");
+        }
+        
+        var selectedAllowedProxyTypeValues = allowedProxyTypes.getAttribute("data-selectedValues");
+        var selectedAllowedProxyTypeValuesArray = [];
+        if (allowedProxyTypes) {
+            selectedAllowedProxyTypeValuesArray = selectedAllowedProxyTypeValues.split(",");
         }
         Alfresco.util.Ajax.jsonGet({
             url: this.listContentTypesUrl,
@@ -386,7 +400,7 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
                     for (var i = 0; i < types.length; i++) {
                         Alfresco.logger.debug("Type index", i);
                         var type = types[i];
-                        var selected = selectedValuesArray.indexOf(type) > -1;
+                        var selected = selectedAllowedTypeValuesArray.indexOf(type) > -1;
                         
                         var typeName = this.msg("type." + type.replace(":", "_"));
             			if (typeName.lastIndexOf("type.", 0) === 0) {
@@ -394,7 +408,23 @@ YAHOO.extend(SoftwareLoop.UploaderPlusAdmin, Alfresco.component.Base, {
 			            }
 			            
                         var option = new Option(typeName, type);
-                        selectNode.add(option);
+                        allowedTypes.add(option);
+                        option.selected = selected;
+                    }
+
+                    var types = response.json.types;
+                    for (var i = 0; i < types.length; i++) {
+                        Alfresco.logger.debug("Type index", i);
+                        var type = types[i];
+                        var selected = selectedAllowedProxyTypeValuesArray.indexOf(type) > -1;
+                        
+                        var typeName = this.msg("type." + type.replace(":", "_"));
+                        if (typeName.lastIndexOf("type.", 0) === 0) {
+                            typeName = type;
+                        }
+                        
+                        var option = new Option(typeName, type);
+                        allowedProxyTypes.add(option);
                         option.selected = selected;
                     }
                 },

--- a/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
@@ -13,6 +13,7 @@
             "/uploader-plus/allowed-content-types",
             
         types : null,
+        proxyTypes : null,
         
         typesLoaded : false,
     
@@ -53,6 +54,7 @@
                     fn: function (response) {
                         Alfresco.logger.debug("loadTypes successCallback", arguments);
                         this.types = response.json.types;
+                        this.proxyTypes = response.json.proxyTypes;
                         this.typesLoaded = true;
                         
                         if (callback) {
@@ -271,7 +273,14 @@
             var formRuntime = this.formUi.formsRuntime;
             var form = Dom.get(formRuntime.formId);
             var propertyData = formRuntime._buildAjaxForSubmit(form);
-            propertyData.contentType = contentType;
+
+            //Replace content type with cm:content for proxy types, to allow aspects to be added
+            if (this.proxyTypes && this.proxyTypes.indexOf(contentType)!==-1) {
+                propertyData.contentType = "cm:content";
+            } else {
+                propertyData.contentType = contentType;
+            }
+            
             this.fileStore[data.id].propertyData = propertyData;
             Alfresco.logger.debug("END processMetadata", propertyData);
         },

--- a/surf/src/main/resources/META-INF/share-config-custom.xml
+++ b/surf/src/main/resources/META-INF/share-config-custom.xml
@@ -16,11 +16,13 @@
             <form>
                 <field-visibility>
                     <show id="up:allowedTypes"/>
+                    <show id="up:allowedProxyTypes"/>
                 </field-visibility>
             </form>
             <form id="upload-folder">
                 <field-visibility>
                     <show id="up:allowedTypes"/>
+                    <show id="up:allowedProxyTypes"/>
                 </field-visibility>
                 <edit-form
                         template="../documentlibrary/forms/doclib-simple-metadata.ftl"/>
@@ -30,6 +32,14 @@
                                 template="/com/softwareloop/uploader-plus/controls/selecttypes.ftl">
                             <control-param name="styleClass">
                                 supported-types-select
+                            </control-param>
+                        </control>
+                    </field>
+                    <field id="up:allowedProxyTypes">
+                        <control
+                                template="/com/softwareloop/uploader-plus/controls/selecttypes.ftl">
+                            <control-param name="styleClass">
+                                supported-proxy-types-select
                             </control-param>
                         </control>
                     </field>


### PR DESCRIPTION
Added the concept of proxy types used to create cm:content with aspects containing custom metadata from a type in the data model. These types should never be created directly but only used when uploading data.

When a type is selected as a proxy type in the admin console for uploader plus and a file is uploaded and the proxy type selected in uploaded plus, the uploader will show the form for the type, but the uploaded file will be of type cm:content with all the aspects of the selected type applied.