### PR TITLE
Add destination as a parameter to the form call

### DIFF
--- a/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
@@ -115,12 +115,13 @@
             var url = YAHOO.lang.substitute(
                     "{serviceContext}components/form" +
                     "?itemKind=type&itemId={itemId}&mode=create&submitType=json" +
-                    "&formId={formId}&showCancelButton=true&htmlid={htmlid}",
+                    "&formId={formId}&showCancelButton=true&htmlid={htmlid}&destination={destination}",
                 {
                     serviceContext: Alfresco.constants.URL_SERVICECONTEXT,
                     itemId: contentType,
                     formId: "upload-folder",
-                    htmlid: formHtmlId
+                    htmlid: formHtmlId,
+		    destination: encodeURIComponent(this.showConfig.destination)
                 }
             );
     


### PR DESCRIPTION
Add destination as a parameter to the form call, to allow for context-dependent share forms.