### PR TITLE
#108 Limit height to 550 px tops

### DIFF
--- a/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
@@ -188,7 +188,7 @@
             }
 
             var formFieldsId = this.id + "-metadata-form-form-fields";
-            YAHOO.util.Dom.setStyle(formFieldsId, 'height', '550px');
+            YAHOO.util.Dom.setStyle(formFieldsId, 'max-height', '550px');
             YAHOO.util.Dom.setStyle(formFieldsId, 'overflow-x', 'auto');
 
     


### PR DESCRIPTION
I already limited height on the form in my PR #105 .

And I got feedback from @douglascrp saying that forcing the form height to 550px can be problematic for relatively small forms (huge white space after the inputs and before the buttons).

In this PR I am replacing `height` style by `max-height` so that small forms are shown as before, where larger forms are limited 550px.