### PR TITLE
set max-lenght to 2000px because it is having some issues when you ar…

### DIFF
--- a/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/uploader-plus-mixin.js
@@ -188,7 +188,7 @@
             }
 
             var formFieldsId = this.id + "-metadata-form-form-fields";
-            YAHOO.util.Dom.setStyle(formFieldsId, 'max-height', '550px');
+            YAHOO.util.Dom.setStyle(formFieldsId, 'max-height', '2000px');
             YAHOO.util.Dom.setStyle(formFieldsId, 'overflow-x', 'auto');
 
     


### PR DESCRIPTION
set max-lenght to 2000px because it is causing some UI issues when you are having more fields.
I tested and found it working fine in my case, increasing the max height it won't cause any other issues.
When you have 15 fields for a content type and you need to scroll down to see/fill fields and help text(?) labels that do  not move when you scroll down.