### PR TITLE
Fix for drag and drop issue which loads the wrong types..

### DIFF
--- a/surf/src/main/amp/web/components/uploader-plus/js/dnd-upload-plus.js
+++ b/surf/src/main/amp/web/components/uploader-plus/js/dnd-upload-plus.js
@@ -28,7 +28,7 @@
             show : function(config)
             {
                 Alfresco.logger.debug("show", arguments);
-                
+                this.typesLoaded = false;
                 SoftwareLoop.DNDUpload.superclass.show.call(this, config);
 
                 this.loadTypes(function () {


### PR DESCRIPTION
To reproduce: Create folder a and apply one applicable type then create another folder b with only one  applicable type(different from folder a). Upload a file in folder a and navigate to folder b and using drag and drop upload a file in folder b. The metadata form displayed shows the right type but the form is wrong. It shows the form for the applicable type set for folder a.