### PR TITLE
Add repository to enable maven compilation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,11 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <!-- Required for spring-social-twitter:1.0.0-RC1 -->
+        <repository>
+            <id>spring-milestone</id>
+            <url>https://repo.spring.io/milestone/</url>
+        </repository>
     </repositories>
 
 </project>


### PR DESCRIPTION
The project cannot compile anymore since the dependency spring-social-twitter:1.0.0-RC1 doesn't exist anymore in maven-central nor Alfresco's nexus.  
This dependency exists in spring-milestone repository, so adding it to the pom solves the problem.