### PR TITLE
Fix issue #110 : run allowed-content-types.get.js as admin

### DIFF
--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.desc.xml
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.desc.xml
@@ -6,4 +6,5 @@
     <url>/uploader-plus/allowed-content-types?destination={destination}</url>
     <format default="json">extension</format>
     <authentication runas="admin">user</authentication>
+    <transaction allow="readonly">required</transaction>
 </webscript>

--- a/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.desc.xml
+++ b/repo/src/main/amp/config/alfresco/templates/webscripts/com/softwareloop/uploader-plus/allowed-content-types.get.desc.xml
@@ -5,5 +5,5 @@
     <url>/uploader-plus/allowed-content-types?siteid={siteid}&amp;containerid={containerid}&amp;path={path}</url>
     <url>/uploader-plus/allowed-content-types?destination={destination}</url>
     <format default="json">extension</format>
-    <authentication>user</authentication>
+    <authentication runas="admin">user</authentication>
 </webscript>


### PR DESCRIPTION
See #110 . 
Problem : 
There is a folder A which contains a folder B.
A user has write permission  on B but has no permission on A.
The user uploads a document in B.
-> The uploader-plus form doesn't show up because of a permission exception, since the webscript which retrieves the allowed types crawls the parent folders to get the uploader-plus configurations.

Solution : Running the webscript as admin simply fixes the issue. 
And forcing the webscript it to execute in a readonly transaction prevents security issues.