### PR TITLE
Issue #143 : remove flash-upload to fix bug in Share with Alfresco 7.1

### DIFF
--- a/surf/src/main/amp/config/alfresco/site-data/extensions/uploader-plus-surf.xml
+++ b/surf/src/main/amp/config/alfresco/site-data/extensions/uploader-plus-surf.xml
@@ -34,17 +34,6 @@
                 <component>
                     <scope>template</scope>
                     <source-id>documentlibrary</source-id>
-                    <region-id>flash-upload</region-id>
-                    <sub-components>
-                        <sub-component id="uploader-plus" index="60">
-                            <url>/components/uploader-plus/flash-upload</url>
-                        </sub-component>
-                    </sub-components>
-                </component>
-
-                <component>
-                    <scope>template</scope>
-                    <source-id>documentlibrary</source-id>
                     <region-id>dnd-upload</region-id>
                     <sub-components>
                         <sub-component id="uploader-plus" index="60">
@@ -67,17 +56,6 @@
                 <component>
                     <scope>template</scope>
                     <source-id>repository</source-id>
-                    <region-id>flash-upload</region-id>
-                    <sub-components>
-                        <sub-component id="uploader-plus" index="60">
-                            <url>/components/uploader-plus/flash-upload</url>
-                        </sub-component>
-                    </sub-components>
-                </component>
-
-                <component>
-                    <scope>template</scope>
-                    <source-id>repository</source-id>
                     <region-id>dnd-upload</region-id>
                     <sub-components>
                         <sub-component id="uploader-plus" index="60">
@@ -93,17 +71,6 @@
                     <sub-components>
                         <sub-component id="uploader-plus" index="60">
                             <url>/components/uploader-plus/html-upload</url>
-                        </sub-component>
-                    </sub-components>
-                </component>
-
-                <component>
-                    <scope>template</scope>
-                    <source-id>myfiles</source-id>
-                    <region-id>flash-upload</region-id>
-                    <sub-components>
-                        <sub-component id="uploader-plus" index="60">
-                            <url>/components/uploader-plus/flash-upload</url>
                         </sub-component>
                     </sub-components>
                 </component>
@@ -130,16 +97,6 @@
                     </sub-components>
                 </component>
 
-                <component>
-                    <scope>template</scope>
-                    <source-id>sharedfiles</source-id>
-                    <region-id>flash-upload</region-id>
-                    <sub-components>
-                        <sub-component id="uploader-plus" index="60">
-                            <url>/components/uploader-plus/flash-upload</url>
-                        </sub-component>
-                    </sub-components>
-                </component>
 
                 <component>
                     <scope>template</scope>


### PR DESCRIPTION
See #143 
When Share loads the component flash-upload in the UI it displays an error because of the following line in flash-upload.get.js#1 from uploader-plus-surf :  
```js
<import resource="classpath:alfresco/site-webscripts/org/alfresco/components/upload/flash-upload.get.js">
```
Because this file doesn't exist anymore in the Share version which comes with Alfresco 7.1, probably because flash is deprecated.

By simply removing references to this flash-upload component, the problem is fixed.